### PR TITLE
Add GET /api/clients route

### DIFF
--- a/sql/getClientList.sql
+++ b/sql/getClientList.sql
@@ -1,0 +1,1 @@
+SELECT id, client_name FROM clients ORDER BY client_name;

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server'
+import { readFile } from 'fs/promises'
+import { pool } from '@/lib/database'
+import type { Client } from '@/types/client'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  try {
+    const sql = await readFile('sql/getClientList.sql', 'utf8')
+    const { rows } = await pool.query<Client>(sql)
+    return NextResponse.json(rows, { headers: { 'Content-Type': 'application/json' } })
+  } catch (err) {
+    console.error('Error fetching client list:', err)
+    return new NextResponse('Internal Server Error', { status: 500 })
+  }
+}

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,0 +1,5 @@
+import { Pool } from 'pg'
+
+export const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+})

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,4 @@
+export interface Client {
+  id: number
+  client_name: string
+}


### PR DESCRIPTION
## Summary
- add pg Pool setup in `src/lib/database.ts`
- define `Client` type
- add SQL query file for getting client list
- implement `/api/clients` API route reading SQL and returning JSON

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c320cb348832ba30033f45c4a8f53