### PR TITLE
Add useClients hook and clients page

### DIFF
--- a/src/app/clients/page.tsx
+++ b/src/app/clients/page.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useClients } from '@/lib/hooks/useClients'
+
+export default function ClientsPage() {
+  const { data, isLoading, error } = useClients()
+
+  if (isLoading) {
+    return <p>Loading…</p>
+  }
+  if (error) {
+    return <p>Error: {error.message}</p>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">ID</th>
+            <th className="px-4 py-2 text-left">Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map(client => (
+            <tr key={client.id} className="border-t">
+              <td className="px-4 py-2">{client.id}</td>
+              <td className="px-4 py-2">{client.client_name}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/lib/hooks/useClients.ts
+++ b/src/lib/hooks/useClients.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Client } from 'src/types/client'
+
+export function useClients() {
+  return useQuery<Client[]>({
+    queryKey: ['clients'],
+    queryFn: async () => {
+      const res = await fetch('/api/clients')
+      if (!res.ok) {
+        throw new Error('Failed to fetch clients')
+      }
+      return res.json() as Promise<Client[]>
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add React Query hook `useClients`
- add `/clients` page that displays a table of clients

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c32f2250c832bb51e7559d15e2b64