### PR TITLE
Add assets listing page and hook

### DIFF
--- a/src/app/assets/page.tsx
+++ b/src/app/assets/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useAssets } from '@/lib/hooks/useAssets'
+
+export default function AssetsPage() {
+  const { data, isLoading, error } = useAssets()
+
+  if (isLoading) {
+    return <p>Loading…</p>
+  }
+  if (error) {
+    return <p>Error: {error.message}</p>
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200 text-sm">
+        <caption className="sr-only">Assets</caption>
+        <thead>
+          <tr>
+            <th className="px-4 py-2 text-left">ID</th>
+            <th className="px-4 py-2 text-left">Name</th>
+            <th className="px-4 py-2 text-left">Purchase Date</th>
+            <th className="px-4 py-2 text-left">Purchase Price</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map(asset => (
+            <tr key={asset.id} className="border-t">
+              <td className="px-4 py-2">{asset.id}</td>
+              <td className="px-4 py-2">{asset.asset_name}</td>
+              <td className="px-4 py-2">
+                {new Date(asset.purchase_date).toLocaleDateString()}
+              </td>
+              <td className="px-4 py-2">{asset.purchase_price}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/lib/hooks/useAssets.ts
+++ b/src/lib/hooks/useAssets.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Asset } from 'src/types/asset'
+
+export function useAssets() {
+  return useQuery<Asset[]>({
+    queryKey: ['assets'],
+    queryFn: async () => {
+      const res = await fetch('/api/assets')
+      if (!res.ok) {
+        throw new Error('Failed to fetch assets')
+      }
+      return res.json() as Promise<Asset[]>
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add React Query hook `useAssets`
- add assets listing client page with table

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c341c3464832ba05036e5f6e6ab4b