### PR TITLE
Add GET endpoint for clients

### DIFF
--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -1,6 +1,29 @@
 // src/app/api/clients/route.ts
+import { readFileSync } from 'fs'
+import path from 'path'
+import { pool } from '@/lib/database'
 import { importClients } from '@/lib/services/importClients'
+import type { Client } from 'src/types/client'
 import type { ClientImport } from 'src/types/clients'
+
+export async function GET() {
+  try {
+    const sql = readFileSync(
+      path.resolve('sql/getClientList.sql'),
+      'utf-8'
+    )
+    const { rows } = await pool.query<Client>(sql)
+    return new Response(JSON.stringify(rows), {
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err: any) {
+    console.error('getClientList error:', err)
+    return new Response(JSON.stringify({ error: err.message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}
 
 export async function POST(req: Request) {
   let body: unknown


### PR DESCRIPTION
## Summary
- add GET handler to fetch client list

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3632b12c832ba029d090fe7ddd5c