### PR TITLE
Fix alias mapping in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-    "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "strict": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- adjust tsconfig alias to map `@/` into `src`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3b439dc4832ba2df2af66f6989db