### PR TITLE
Fix alias for backend services

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*", "./lib/*"]
     },
     "strict": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary
- adjust tsconfig `paths` so `@/lib/*` resolves correctly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3e17a964832b854d7517db5cda94